### PR TITLE
Closes #9

### DIFF
--- a/src/authnet/AuthnetWebhook.php
+++ b/src/authnet/AuthnetWebhook.php
@@ -135,7 +135,7 @@ class AuthnetWebhook
             $headers = [];
             foreach ($_SERVER as $key => $value) {
                 if (strpos($key, 'HTTP_') === 0) {
-                    $headers[ str_replace('_', '-', substr($key, 5)) ] = $value;
+                    $headers[str_replace('_', '-', substr($key, 5))] = $value;
                 }
             }
         }

--- a/src/authnet/AuthnetWebhook.php
+++ b/src/authnet/AuthnetWebhook.php
@@ -132,9 +132,12 @@ class AuthnetWebhook
         if (function_exists('apache_request_headers')) {
             $headers = apache_request_headers();
         } else {
-            $headers = array_filter($_SERVER, function($key) {
-                return strpos($key, 'HTTP_') === 0;
-            }, ARRAY_FILTER_USE_KEY);
+            $headers = [];
+            foreach ($_SERVER as $key => $value) {
+                if (strpos($key, 'HTTP_') === 0) {
+                    $headers[ str_replace('_', '-', substr($key, 5)) ] = $value;
+                }
+            }
         }
         return $headers;
     }


### PR DESCRIPTION
Ensure correct header keys when apache_request_headers is not defined.

@stymiee I'm using the PHP 5.6 branch at the moment, hence making this change there, but it looks like `master` has the exact same issue.